### PR TITLE
Add port to vhost configurations

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,11 +105,11 @@ class nginx   (
       content => template("${module_name}/default_vhost_template.erb"),
       notify  => Service['nginx'],
       before  => Service['nginx'],
-      require => Exec [
-                        "mkdir_p_${defaultdocroot}",
-                        "mkdir_p_${nginx::params::sites_dir}",
-                        "mkdir_p_${nginx::params::sites_enabled_dir}"
-                      ],
+      require => Exec[
+        "mkdir_p_${defaultdocroot}",
+        "mkdir_p_${nginx::params::sites_dir}",
+        "mkdir_p_${nginx::params::sites_enabled_dir}"
+      ],
     }
 
     file { "${nginx::params::sites_enabled_dir}/default":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class nginx   (
       $username=$nginx::params::username,
       $pidfile='/var/run/nginx.pid',
       $add_default_vhost=true,
+      $default_vhost_port=80,
     ) inherits nginx::params{
 
   validate_absolute_path($defaultdocroot)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,13 +4,22 @@ class nginx::params {
   $sites_dir='/etc/nginx/sites-available'
   $sites_enabled_dir='/etc/nginx/sites-enabled'
   $servertokens_default='off'
-  $gziptypes_default= [ 'text/plain', 'text/css', 'application/json', 'application/x-javascript', 'text/xml', 'application/xml', 'application/xml+rss', 'text/javascript' ]
+  $gziptypes_default= [
+    'text/plain',
+    'text/css',
+    'application/json',
+    'application/x-javascript',
+    'text/xml',
+    'application/xml',
+    'application/xml+rss',
+    'text/javascript'
+  ]
 
   case $::osfamily
   {
     'redhat':
     {
-			$package='nginx'
+      $package='nginx'
       case $::operatingsystemrelease
       {
         /^[67].*$/:
@@ -34,7 +43,7 @@ class nginx::params {
           {
             /^14.*$/:
             {
-							$purge_default_vhost=undef
+              $purge_default_vhost=undef
               $package='nginx-light'
               $include_epel=false
               $username='www-data'

--- a/templates/default_vhost_template.erb
+++ b/templates/default_vhost_template.erb
@@ -1,5 +1,5 @@
 server {
-	listen 80 default_server;
+	listen <%= @default_vhost_port %> default_server;
 
 	root <%= @defaultdocroot %>;
 	index index.html index.htm;

--- a/templates/vhost/template_vhost.erb
+++ b/templates/vhost/template_vhost.erb
@@ -1,5 +1,5 @@
 server {
-	listen 80<% if @default %> default_server <% end %>;
+	listen <%= @port %> <% if @default %> default_server <% end %>;
 
 	root <%= @documentroot %>;
 	index <%= @directoryindex.join(' ') %>;


### PR DESCRIPTION
Add port as parameter to the VHosts templates so it can be
customized:
- Added "port" variable to template_vhost.
- Added default_vhost_port variable to init.pp.
- Added default_vhost_port variable to default_vhost_template.
